### PR TITLE
CORE 1459 - Redirect pages to the new docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,5 @@ github_username:  zype
 permalink: '/posts/:year/:month/:day/:title/'
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-redirect-from

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -10,3 +10,5 @@ github_username:  zype
 permalink: '/posts/:year/:month/:day/:title/'
 # Build settings
 markdown: kramdown
+plugins:
+  - jekyll-redirect-from

--- a/api_docs/3rd-party-CRM-integration.md
+++ b/api_docs/3rd-party-CRM-integration.md
@@ -2,15 +2,16 @@
 layout: api
 title:  "3rd Party Payment Provider & Subscription Management Quickstart | Common API Examples"
 permalink:  /api_docs/3rd-party-crm-integration/
+redirect_to: https://docs.zype.com/v1.0/reference#3rd-party-payment-provider-subscription-management-quickstart
 ---
 
 # 3rd Party Payment Provider & Subscription Management Quickstart
 
 What does this solution do?
 Zype provides an effective way of importing and managing an external database of consumers within the Zype platform. This is useful if you are using a 3rd party payment processor to sell subscriptions or a 3rd party CRM tool to manage your customer database and would also like to import and track these customers in the Zype platform.
- 
+
 Once imported into the Zype platform, benefits include ensuring these customers have access to content across all of your distribution endpoints via Universal login.
- 
+
 This workflow involves use of Zype’s Consumer, Subscription, and Linked Devices APIs. This document provides details on how to integrate subscription customers and transactions processed via 3rd party payment processors.
 
 
@@ -29,21 +30,21 @@ In order to utilize Zype’s RESTful API service to implement 3rd party payment 
 Importing and managing consumers and subscriptions stored in a 3rd party database is easy to do with Zype, typically requiring only three steps:
 
 1. Create a consumer user in your own platform’s database
- 
+
 2. Create corresponding Zype consumer user to match to your database consumer
- 
+
 3. Create a subscription for the Zype consumer
 
 ### Step 1: Create a consumer user in your own platform’s database
 
 Consumers are used to represent users in the Zype platform. Consumer records can be used to store basic user login information, including email, name and password. Consumers can also be used to store subscription information, and if credentials are supplied, process payments and subscriptions from Stripe or Braintree.
- 
+
 Creating a consumer user in your database is typically handled prior to transaction processing, during your account sign up or account creation flow. This is not dependent on the Zype platform, but is required for importing or creating a consumer record in the Zype database.
 
 ### Step 2: Create the corresponding consumer user in Zype
 
 Once you’ve created a consumer in your database, you should also create a consumer in the Zype platform via our Consumer API. This will ensure that you can track all consumers who are creating accounts via your 3rd party payment processors or CRMs, and that those consumers can have access to any subscription content they purchase directly through you.
- 
+
 Consumer objects are generally used in the following ways in the Zype platform:
 
 * To store subscription, transaction, entitlement, and payment information about users.
@@ -51,16 +52,16 @@ Consumer objects are generally used in the following ways in the Zype platform:
 * To optionally provide login capabilities for your platform. Depending on your use case this may not be required, but if you’d like to utilize login capabilities simply provide a password for consumers when they are created.
 
 The minimum required fields to create a user is their email address. You can also supply additional information including the consumer’s name, birthday, or gender by supplying values in the POST request. Although optional, typically all consumer objects include passwords upon creation (to enable login / authentication across your content distribution endpoints).
- 
+
 Once you create a consumer in Zype, you’ll want to create a relational record for the consumer between Zype and your own database. We suggest using the Zype consumer ID for this purpose. The consumer ID of a Zype created consumer is returned upon successful creation via API. (example consumer_id value: 54579a634c61450389000000)
- 
-To create consumers via API, you will need to supply your admin API key in the API request. 
+
+To create consumers via API, you will need to supply your admin API key in the API request.
 
 Consumer API Endpoint
 POST - https://api.zype.com/consumers/
- 
+
 Example Request:
-{% highlight xml %} 
+{% highlight xml %}
 curl https://api.zype.com/consumers/  \
    -d api_key="[YOUR ADMIN KEY]" \
    -d consumer[email]="email@example.com" \
@@ -68,7 +69,7 @@ curl https://api.zype.com/consumers/  \
    -d consumer[password]="ExamplePassword"
 
 Example Response:
- 
+
 {
   "response": {
     "_id": "54579a634c61450389000000",
@@ -81,29 +82,29 @@ Example Response:
     "updated_at": "2014-11-03T15:08:19.675Z"
   }
 }
-{% endhighlight %} 
+{% endhighlight %}
 For a full listed of supported API commands please visit our API documentation: [Zype Consumer API Documentation](http://dev.zype.com/api_docs/consumers/)
 
 
 ### Step 3: Create a subscription for a Zype consumer
 
-Subscriptions are used to track that a consumer has subscribed to content on your platform and should have entitlement to your premium subscription library. There are three types of subscriptions available: Basic, Stripe or Braintree. 
- 
+Subscriptions are used to track that a consumer has subscribed to content on your platform and should have entitlement to your premium subscription library. There are three types of subscriptions available: Basic, Stripe or Braintree.
+
 Basic subscriptions are used to indicate that a user has subscribed to your content without having a Zype integrated payment provider to process payment. For any subscriptions purchased through your 3rd party payment processor, you’ll create Basic subscriptions via Zype’s Subscription API.
 
 Stripe and Braintree subscriptions require a payment token be provided from the respective provider when creating the subscription. Zype will then process the payment through the respective provider on your behalf.
- 
+
 Subscriptions should be created after your users has provided payment details. If you would like to manage payment processing yourself use a “basic” subscription which will only track that a user is subscribed to a plan. Stripe or Braintree subscriptions can be utilized if you have Zype manage subscriptions on your behalf via our embeddable widgets.
- 
+
 Once a consumer purchases via your 3rd party payment processor, you’ll want to create a Basic subscription in the Zype platform. After creating the Basic subscription, you should create a relational record between the subscription record in Zype and your own database. We suggest using the Zype subscription ID for this purpose. The subscription ID of a Zype created subscription is returned upon successful creation of the subscription. (example subscription_id: 54579a634c61450389000000)
- 
+
 To create subscriptions you will need to supply your admin API key in the API request. You will also need to have a consumer and plan set up in the Zype platform to subscribe to.
 
 Subscription API Endpoint
-POST - https://api.zype.com/subscriptions 
- 
+POST - https://api.zype.com/subscriptions
+
 Example Request:
-{% highlight xml %}  
+{% highlight xml %}
 curl https://api.zype.com/subscriptions \
    -d api_key="[YOUR ADMIN KEY]" \
    -d subscription[third_party_id]=[THIRD PARTY ID IN YOUR PLAN]\
@@ -111,7 +112,7 @@ curl https://api.zype.com/subscriptions \
    -d subscription[consumer_id]="54579a634c61450389000000" \
 
 Example Response:
- 
+
 {
   "response": {
     "_id": "54579a634c61450389000000",
@@ -128,12 +129,12 @@ Example Response:
     "updated_at": "2014-11-03T15:08:19.675Z"
   }
 }
-{% endhighlight %} 
-For a full list of supported API commands please visit our API documentation: 
+{% endhighlight %}
+For a full list of supported API commands please visit our API documentation:
 [Zype Subcription API Documentation](http://dev.zype.com/api_docs/subscriptions/)
 
 
 Reference Materials:
- 
+
 API Documentation: [Zype API Documentation](http://dev.zype.com/api_docs/intro/)
 API Keys: [Zype Property API Keys](https://admin.zype.com/api_keys)

--- a/api_docs/ad_tag.md
+++ b/api_docs/ad_tag.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Ad Tags
 permalink: /api_docs/ad_tags/
+redirect_to: https://docs.zype.com/reference#ad-tags
 ---
 
 ## Ad Tags

--- a/api_docs/analytics.md
+++ b/api_docs/analytics.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Analytics
 permalink: /api_docs/analytics/
+redirect_to: https://docs.zype.com/reference#stream-hours
 ---
 
 ## Analytics

--- a/api_docs/apps.md
+++ b/api_docs/apps.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Apps
 permalink: /api_docs/apps/
+redirect_to: https://docs.zype.com/reference#apps
 ---
 
 # Apps
@@ -32,7 +33,7 @@ Parameter | Function | Type
 app_key   | The app key | String
 
 ## App Object
-App profiles vary by the type of application. 
+App profiles vary by the type of application.
 
 ```
 {

--- a/api_docs/categories.md
+++ b/api_docs/categories.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Categories
 permalink: /api_docs/categories/
+redirect_to: https://docs.zype.com/reference#categories
 ---
 
 ## Categories

--- a/api_docs/consumers.md
+++ b/api_docs/consumers.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Consumers
 permalink: /api_docs/consumers/
+redirect_to: https://docs.zype.com/reference#consumers
 ---
 
 ## Consumers

--- a/api_docs/content_rules_category.md
+++ b/api_docs/content_rules_category.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Category Content Rules
 permalink: /api_docs/content_rules_category/
+redirect_to: https://docs.zype.com/reference#category-content-rules
 ---
 
 ## Category Content Rules

--- a/api_docs/content_rules_playlist.md
+++ b/api_docs/content_rules_playlist.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Playlist Content Rules
 permalink: /api_docs/content_rules_playlist/
+redirect_to: https://docs.zype.com/reference#playlist-content-rules
 ---
 
 ## Playlist Content Rules

--- a/api_docs/content_rules_video.md
+++ b/api_docs/content_rules_video.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Content Rules
 permalink: /api_docs/content_rules_video/
+redirect_to: https://docs.zype.com/reference#video-content-rules
 ---
 
 ## Video Content Rules

--- a/api_docs/device.md
+++ b/api_docs/device.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Devices
 permalink: /api_docs/devices/
+redirect_to: https://docs.zype.com/reference#devices
 ---
 
 ## Devices

--- a/api_docs/device_category.md
+++ b/api_docs/device_category.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Device Categories
 permalink: /api_docs/device_categories/
+redirect_to: https://docs.zype.com/reference#device-categories
 ---
 
 ## Device Categories

--- a/api_docs/device_linking.md
+++ b/api_docs/device_linking.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Device Linking
 permalink: /api_docs/device_linking/
+redirect_to: https://docs.zype.com/reference#device-linking
 ---
 
 ## Device Linking

--- a/api_docs/geoIP.md
+++ b/api_docs/geoIP.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | GeoIP
 permalink: /api_docs/geoip/
+redirect_to: https://docs.zype.com/reference#geoip
 ---
 
 ## GeoIP

--- a/api_docs/manifests.md
+++ b/api_docs/manifests.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Manifests
 permalink: /api_docs/manifests/
+redirect_to: https://docs.zype.com/reference#manifests
 ---
 
 ## Video Manifests Collection

--- a/api_docs/oauth.md
+++ b/api_docs/oauth.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | OAuth
 permalink: /api_docs/oauth/
+redirect_to: https://docs.zype.com/reference#oauth-1
 ---
 ## OAuth
 <hr>

--- a/api_docs/plans.md
+++ b/api_docs/plans.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Subscription Plans
 permalink: /api_docs/plans/
+redirect_to: https://docs.zype.com/reference#plans
 ---
 
 # Subscription Plans

--- a/api_docs/players.md
+++ b/api_docs/players.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Native Players
 permalink: /api_docs/players/
+redirect_to: https://docs.zype.com/reference#players
 ---
 
 # Players
@@ -19,9 +20,9 @@ For native devices like iOS, Android, and OTT set-top boxes, the Player API will
 
 Developers need to specify User-Agent for all requests that are coming from Native Players.
 
-Device | User-Agent 
---------- | -------- 
-Android (Native) | zype android 
+Device | User-Agent
+--------- | --------
+Android (Native) | zype android
 Apple TV | zype tvos
 Amazon Fire TV | AmazonWebAppPlatform
 Roku | Roku

--- a/api_docs/playlist_entitlements.md
+++ b/api_docs/playlist_entitlements.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Playlists
 permalink: /api_docs/playlist_entitlements/
+redirect_to: https://docs.zype.com/reference#playlist-entitlements
 ---
 
 ## Playlist Entitlements

--- a/api_docs/playlists.md
+++ b/api_docs/playlists.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Playlists
 permalink: /api_docs/playlists/
+redirect_to: https://docs.zype.com/reference#playlists
 ---
 
 ## Playlists

--- a/api_docs/program_guides.md
+++ b/api_docs/program_guides.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Program Guides
 permalink: /api_docs/program_guides/
+redirect_to: https://docs.zype.com/reference#program-guides
 ---
 
 ## Program Guides

--- a/api_docs/redemption_codes.md
+++ b/api_docs/redemption_codes.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Redemption Codes
 permalink: /api_docs/redemption_codes/
+redirect_to: https://docs.zype.com/reference#redemption-codes
 ---
 
 ## Redemption Codes

--- a/api_docs/revenue_model.md
+++ b/api_docs/revenue_model.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Revenue Models
 permalink: /api_docs/revenue_models/
+redirect_to: https://docs.zype.com/reference#revenue-models
 ---
 
 ## Revenue Models

--- a/api_docs/segments.md
+++ b/api_docs/segments.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Segments
 permalink: /api_docs/segments/
+redirect_to: https://docs.zype.com/reference#segments
 ---
 
 ## Segments

--- a/api_docs/subscriptions.md
+++ b/api_docs/subscriptions.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Subscriptions
 permalink: /api_docs/subscriptions/
+redirect_to: https://docs.zype.com/reference#subscriptions
 ---
 
 ## Subscriptions Collection

--- a/api_docs/subtitle_playlists.md
+++ b/api_docs/subtitle_playlists.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Subtitle Playlists
 permalink: /api_docs/subtitle_playlists/
+redirect_to: https://docs.zype.com/reference#subtitle-playlists
 ---
 
 # Subtitle Playlists

--- a/api_docs/subtitles.md
+++ b/api_docs/subtitles.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Videos
 permalink: /api_docs/subtitles/
+redirect_to: https://docs.zype.com/reference#subtitles
 ---
 
 # Subtitles
@@ -38,7 +39,7 @@ Get an **array** of [subtitle objects](#subtitle-object) from a specific video.
 
 Parameter | Function | Type
 --------- | -------- | ----
-video_id  | ID of the Video object that contains the subtitle (Example: `video_id=5389352e69702d401b000000`) | String 
+video_id  | ID of the Video object that contains the subtitle (Example: `video_id=5389352e69702d401b000000`) | String
 
 ## Retrieve a Subtitle
 ```
@@ -52,7 +53,7 @@ Get a single subtitle by ID.
 
 Parameter | Function | Type
 --------- | -------- | ----
-video_id  | ID of the Video object that contains the subtitle (Example: `video_id=5389352e69702d401b000000`) | String 
+video_id  | ID of the Video object that contains the subtitle (Example: `video_id=5389352e69702d401b000000`) | String
 id        | ID of the Subtitle record to retrieve (Example: `id=59c93e3a02eac40026000005`) | String
 
 ## Create a Subtitle

--- a/api_docs/transactions.md
+++ b/api_docs/transactions.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Transactions
 permalink: /api_docs/transactions/
+redirect_to: https://docs.zype.com/reference#transactions
 ---
 
 ## Transactions Collection

--- a/api_docs/video_entitlements.md
+++ b/api_docs/video_entitlements.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Entitlements
 permalink: /api_docs/video_entitlements/
+redirect_to: https://docs.zype.com/reference#video-entitlements
 ---
 
 ## Video Entitlements

--- a/api_docs/video_favorites.md
+++ b/api_docs/video_favorites.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Favorites
 permalink: /api_docs/video_favorites/
+redirect_to: https://docs.zype.com/reference#video-favorites
 ---
 
 # Video Favorites
@@ -33,14 +34,14 @@ Get an **array** of Video Favorite Objects for the specified Consumer.
 ### Use Case
 Use this endpoint to retrieve and/or display a Consumer's Video Favorites.
 
-**Example 1**  
+**Example 1**
 List a Consumer's Video Favorites in one area of an app for convenient access.
 
 ```
 /**
  * List Consumer's Video Favorites
- * 
- * @NOTE Pseudocode 
+ *
+ * @NOTE Pseudocode
  */
 
 // Get Video Favorites
@@ -50,21 +51,21 @@ var video_favorites = GET https://api.zype.com/consumers/[consumer_id]/video_fav
 for (var i = 0; i < video_favorites.length; i++) {
   // Get the Video Favorite video_id
   var video_id = video_favorites[i].video_id;
-	
+
   // Get Video by ID
   var video = GET https://api.zype.com/videos/[video_id]
-  
+
   // Do something with retrieved video
 }
 ```
-**Example 2**  
+**Example 2**
 Visually designate a Consumer's Video Favorites inline with a [List Videos](http://dev.zype.com/api_docs/videos/#list-videos) query.
 
 ```
 /**
  * Display Video Favorites Inline
- * 
- * @NOTE Pseudocode 
+ *
+ * @NOTE Pseudocode
  */
 
 // Get Video Favorites
@@ -108,10 +109,10 @@ video_id | ID of the video object (Example: `56d7594a0f8asd081208e4`)  | String
 DELETE https://api.zype.com/consumers/[consumer_id]/video_favorites/[video_favorite_id]
 
 /**
- * @NOTE Some client-side languages / libraries (JavaScript, jQuery, etc.) 
+ * @NOTE Some client-side languages / libraries (JavaScript, jQuery, etc.)
  *       must use POST with `_method=delete` parameter and value specifed.
  */
- 
+
 POST https://api.zype.com/consumers/[consumer_id]/video_favorites/[video_favorite_id]?_method=delete
 ```
 

--- a/api_docs/video_imports.md
+++ b/api_docs/video_imports.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Imports
 permalink: /api_docs/video_imports/
+redirect_to: https://docs.zype.com/reference#video-imports
 ---
 
 ## Video Imports
@@ -49,7 +50,7 @@ video_id  | ID of a video to add the record to (Example: 5389352e69702d401b00000
   "_id": "5499c02d4c616e0545000000",
   "active": true,
   "created_at": "2014-12-23T14:19:09.369-05:00",
-  "description": 
+  "description":
     "She came to the Tiny Desk a little unsure, and left singing \"West Memphis\" with intensity and passion ...",
   "duration": 1195,
   "episode": nil,
@@ -59,7 +60,7 @@ video_id  | ID of a video to add the record to (Example: 5389352e69702d401b00000
   "season": nil,
   "site_id": "12345abcd",
   "status": "ready",
-  "thumbnails": 
+  "thumbnails":
   [
     {"aspect_ratio": nil,
     "height": 90,

--- a/api_docs/video_sources.md
+++ b/api_docs/video_sources.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Video Sources
 permalink: /api_docs/video_sources/
+redirect_to: https://docs.zype.com/reference#video-sources
 ---
 
 ## Video Sources Collection

--- a/api_docs/videos.md
+++ b/api_docs/videos.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Videos
 permalink: /api_docs/videos/
+redirect_to: https://docs.zype.com/reference#videos
 ---
 
 # Videos

--- a/api_docs/zobject_docs.md
+++ b/api_docs/zobject_docs.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Zobjects
 permalink: /api_docs/zobject_docs/
+redirect_to: https://docs.zype.com/reference#zobject
 ---
 
 ## Zobjects

--- a/api_docs/zobject_types.md
+++ b/api_docs/zobject_types.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Zobject Types
 permalink: /api_docs/zobject_types/
+redirect_to: https://docs.zype.com/reference#zobject-types
 ---
 
 ## Zobject Types

--- a/api_docs/zobjects.md
+++ b/api_docs/zobjects.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Zobjects
 permalink: /api_docs/zobjects/
+redirect_to: https://docs.zype.com/reference#zobject
 ---
 
 ## Zobjects Collection

--- a/api_docs/zype_platform.md
+++ b/api_docs/zype_platform.md
@@ -2,6 +2,7 @@
 layout: api
 title: Zype Developer Portal | Zype Platform
 permalink: /api_docs/zype_platform/
+redirect_to: https://docs.zype.com/v1.0/reference#welcome-to-the-zype-api-documentation
 ---
 
 ## Zype Platform

--- a/api_intro.md
+++ b/api_intro.md
@@ -2,6 +2,7 @@
 layout: api_intro
 title: Zype Developer Portal | API
 permalink: /api_docs/intro/
+redirect_to: https://docs.zype.com/reference
 ---
 
 ## Introduction

--- a/index.html.md
+++ b/index.html.md
@@ -2,6 +2,7 @@
 layout: default
 title: Zype Developer Portal | Home
 permalink: /
+redirect_to: "https://docs.zype.com/"
 ---
 
 <h2 class="hidden-mobile">Welcome to the Zype Developer Portal</h2>


### PR DESCRIPTION
Redirects from the old developer portal to the new one, for SEO purposes. 
We use https://github.com/jekyll/jekyll-redirect-from#redirect-to, it doesn't use a 301 redirect but a `<link rel="canonical" href="https://docs.zype.com/reference">`. Google take that link as a 301, [doc here](https://support.google.com/webmasters/answer/139066?hl=en)

Jira: https://zypeinc.atlassian.net/browse/CORE-1459